### PR TITLE
borrow tests

### DIFF
--- a/test/test_cases/neg_borrow.out
+++ b/test/test_cases/neg_borrow.out
@@ -1,0 +1,1 @@
+Fatal error: exception Failure("variable x is already immutably borrowed, thus it cant be mutably borrowed.")

--- a/test/test_cases/neg_borrow.ppus
+++ b/test/test_cases/neg_borrow.ppus
@@ -1,0 +1,10 @@
+/* try to mutably borrow a borrowed variable */
+pipe main |> [] |> [] |> unit {
+  int x <| 0;
+  {
+    &int y <| &x;
+    &int z <| &x;
+    ~&int a <| ~&x;
+  }
+  |> ();
+}

--- a/test/test_cases/neg_borrow1.out
+++ b/test/test_cases/neg_borrow1.out
@@ -1,0 +1,8 @@
+pipe main |> [] |> [] |> unit {
+  (unit : );
+{
+  (unit : );
+  (unit : );
+}
+  (unit : );
+}

--- a/test/test_cases/neg_borrow1.ppus
+++ b/test/test_cases/neg_borrow1.ppus
@@ -1,0 +1,9 @@
+/* try to immutably borrow a mutably borrowed variable */
+pipe main |> [] |> [] |> unit {
+  int x <| 0;
+  {
+    ~&int y <| ~&y;
+    &int z <| &x;
+  }
+  |> ();
+}


### PR DESCRIPTION
we will prob need to re-write our tests since they check against -a, so things like semantic errors aren't passing.